### PR TITLE
chore(deps): update default registry's baseline to `b322364f06308bdd24823f9d8f03fe0cc86fd46f`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "3508985146f1b1d248c67ead13f8f54be5b4f5da"
+    "baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `b322364f06308bdd24823f9d8f03fe0cc86fd46f`.