### PR TITLE
test: fix data race in tests

### DIFF
--- a/test/threadpool.cpp
+++ b/test/threadpool.cpp
@@ -93,11 +93,7 @@ TEST_F(ThreadPoolTest, ParallelExecution)
         });
     }
 
-    while (!latch.try_wait()) {
-        std::this_thread::yield();
-        constexpr auto DELAY = 10U;
-        std::this_thread::sleep_for(std::chrono::microseconds(DELAY));
-    }
+    latch.wait();
 
     EXPECT_EQ(this->m_pool->max_active_threads(), ThreadPoolTest::NUM_THREADS);
     EXPECT_EQ(this->m_pool->active_threads(), ThreadPoolTest::NUM_THREADS);
@@ -110,7 +106,9 @@ TEST_F(ThreadPoolTest, ParallelExecution)
     this->m_pool->wait();
 
     EXPECT_EQ(this->m_pool->tasks_completed(), ThreadPoolTest::NUM_THREADS);
+    sem.acquire();
     EXPECT_THAT(results, ::testing::UnorderedElementsAreArray(expected.begin(), expected.end()));
+    sem.release();
 }
 
 TEST(ConstructionDestructionTest, DefaultConstruction)
@@ -140,11 +138,7 @@ TEST(ConstructionDestructionTest, DestructionWithActiveTasks)
             );
         }
 
-        while (!latch.try_wait()) {
-            std::this_thread::yield();
-            constexpr auto DELAY = 10U;
-            std::this_thread::sleep_for(std::chrono::microseconds(DELAY));
-        }
+        latch.wait();
 
         EXPECT_EQ(pool.active_threads(), NUM_THREADS);
         EXPECT_EQ(pool.work_queue_size(), NUM_TASKS - NUM_THREADS);


### PR DESCRIPTION
```
WARNING: ThreadSanitizer: data race (pid=3295093)
  Read of size 8 at 0x7fffffffd038 by main thread:
    #0 __gnu_cxx::__normal_iterator<unsigned int const*, std::vector<unsigned int, std::allocator<unsigned int>>>::__normal_iterator(unsigned int const* const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_iterator.h:1077:20 (test_threadpool+0x112429
    #1 std::vector<unsigned int, std::allocator<unsigned int>>::end() const /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_vector.h:904:16 (test_threadpool+0x112429)
    #2 testing::internal::UnorderedElementsAreMatcherImpl<std::vector<unsigned int, std::allocator<unsigned int>> const&>::MatchAndExplain(std::vector<unsigned int, std::allocator<unsigned int>> const&, testing::MatchResultListener*) const /usr/include/gmock/gmock-matchers.h:3648:
    #3 decltype(testing::internal::MatcherBase<std::vector<unsigned int, std::allocator<unsigned int>> const&>::ValuePolicy<testing::MatcherInterface<std::vector<unsigned int, std::allocator<unsigned int>> const&> const*, true>::Get(fp).MatchAndExplain(fp0, fp1)) testing::internal
    #4 testing::internal::MatcherBase<std::vector<unsigned int, std::allocator<unsigned int>> const&>::MatchAndExplain(std::vector<unsigned int, std::allocator<unsigned int>> const&, testing::MatchResultListener*) const /usr/include/gtest/gtest-matchers.h:234:12 (test_threadpool+0
    #5 testing::internal::MatcherBase<std::vector<unsigned int, std::allocator<unsigned int>> const&>::Matches(std::vector<unsigned int, std::allocator<unsigned int>> const&) const /usr/include/gtest/gtest-matchers.h:240:12 (test_threadpool+0x111461)
    #6 testing::AssertionResult testing::internal::PredicateFormatterFromMatcher<testing::internal::UnorderedElementsAreArrayMatcher<unsigned int>>::operator()<std::vector<unsigned int, std::allocator<unsigned int>>>(char const*, std::vector<unsigned int, std::allocator<unsigned i
    #7 ThreadPoolTest_ParallelExecution_Test::TestBody() /home/volodymyr/work/simple-threadpool/test/threadpool.cpp:113:5 (test_threadpool+0x10ce02) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #8 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (test_threadpool+0x15c55e) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)

  Previous write of size 8 at 0x7fffffffd038 by thread T4:
    #0 std::vector<unsigned int, std::allocator<unsigned int>>::push_back(unsigned int const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_vector.h:1288:6 (test_threadpool+0x10e2a9) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #1 ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0::operator()(std::stop_token const&) const /home/volodymyr/work/simple-threadpool/test/threadpool.cpp:91:21 (test_threadpool+0x10e2a9)
    #2 void std::__invoke_impl<void, ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0&, std::stop_token const&>(std::__invoke_other, ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0&, std::stop_token const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c
    #3 std::enable_if<is_invocable_r_v<void, ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0&, std::stop_token const&>, void>::type std::__invoke_r<void, ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0&, std::stop_token const&>(ThreadPoolTest_ParallelExecution_Test::
    #4 std::_Function_handler<void (std::stop_token const&), ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0>::_M_invoke(std::_Any_data const&, std::stop_token const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9 (test_threadp
    #5 std::function<void (std::stop_token const&)>::operator()(std::stop_token const&) const /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9 (test_threadpool+0x1172ec) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #6 wwa::thread_pool_private::run_task(std::shared_ptr<wwa::work_item> const&) /home/volodymyr/work/simple-threadpool/src/threadpool_p.cpp:188:9 (test_threadpool+0x1172ec)
    #7 wwa::thread_pool_private::worker_thread(std::stop_token const&, wwa::thread_pool_private*, unsigned long) /home/volodymyr/work/simple-threadpool/src/threadpool_p.cpp:168:23 (test_threadpool+0x115ba2) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #8 void std::__invoke_impl<void, void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>(std::__invoke_other, void (*&&)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_
    #9 std::__invoke_result<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>::type std::__invoke<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::
    #10 void std::thread::_Invoker<std::tuple<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>>::_M_invoke<0ul, 1ul, 2ul, 3ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) /usr/bin/../lib/gcc/x86_64-li
    #11 std::thread::_Invoker<std::tuple<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>>::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:299:1
    #12 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>>>::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/b
    #13 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)

  As if synchronized via sleep:
    #0 nanosleep <null> (test_threadpool+0x730a1) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #1 void std::this_thread::sleep_for<long, std::ratio<1l, 1000000l>>(std::chrono::duration<long, std::ratio<1l, 1000000l>> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/this_thread_sleep.h:80:9 (test_threadpool+0x10c51a) (BuildId: d7b3726e31c43
    #2 ThreadPoolTest_ParallelExecution_Test::TestBody() /home/volodymyr/work/simple-threadpool/test/threadpool.cpp:99:9 (test_threadpool+0x10c51a)
    #3 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (test_threadpool+0x15c55e) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
```

```
WARNING: ThreadSanitizer: data race (pid=3295093)
  Read of size 4 at 0x72040000022c by main thread:
    #0 decltype(std::forward<unsigned int const&>(fp) == std::forward<unsigned int const&>(fp0)) std::equal_to<void>::operator()<unsigned int const&, unsigned int const&>(unsigned int const&, unsigned int const&) const /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c+
    #1 bool testing::internal::ComparisonBase<testing::internal::EqMatcher<unsigned int>, unsigned int, std::equal_to<void>>::MatchAndExplain<unsigned int>(unsigned int const&, std::ostream*) const /usr/include/gtest/gtest-matchers.h:700:12 (test_threadpool+0x112f14)
    #2 decltype(testing::internal::MatcherBase<unsigned int const&>::ValuePolicy<testing::internal::EqMatcher<unsigned int>, true>::Get(fp).MatchAndExplain(fp0, fp1->stream())) testing::internal::MatcherBase<unsigned int const&>::MatchAndExplainImpl<testing::internal::MatcherBase<
    #3 testing::internal::MatcherBase<unsigned int const&>::MatchAndExplain(unsigned int const&, testing::MatchResultListener*) const /usr/include/gtest/gtest-matchers.h:234:12 (test_threadpool+0x113415) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #4 testing::internal::MatchMatrix testing::internal::UnorderedElementsAreMatcherImpl<std::vector<unsigned int, std::allocator<unsigned int>> const&>::AnalyzeElements<__gnu_cxx::__normal_iterator<unsigned int const*, std::vector<unsigned int, std::allocator<unsigned int>>>>(__g
    #5 testing::internal::UnorderedElementsAreMatcherImpl<std::vector<unsigned int, std::allocator<unsigned int>> const&>::MatchAndExplain(std::vector<unsigned int, std::allocator<unsigned int>> const&, testing::MatchResultListener*) const /usr/include/gmock/gmock-matchers.h:3648:
    #6 decltype(testing::internal::MatcherBase<std::vector<unsigned int, std::allocator<unsigned int>> const&>::ValuePolicy<testing::MatcherInterface<std::vector<unsigned int, std::allocator<unsigned int>> const&> const*, true>::Get(fp).MatchAndExplain(fp0, fp1)) testing::internal
    #7 testing::internal::MatcherBase<std::vector<unsigned int, std::allocator<unsigned int>> const&>::MatchAndExplain(std::vector<unsigned int, std::allocator<unsigned int>> const&, testing::MatchResultListener*) const /usr/include/gtest/gtest-matchers.h:234:12 (test_threadpool+0
    #8 testing::internal::MatcherBase<std::vector<unsigned int, std::allocator<unsigned int>> const&>::Matches(std::vector<unsigned int, std::allocator<unsigned int>> const&) const /usr/include/gtest/gtest-matchers.h:240:12 (test_threadpool+0x111461)
    #9 testing::AssertionResult testing::internal::PredicateFormatterFromMatcher<testing::internal::UnorderedElementsAreArrayMatcher<unsigned int>>::operator()<std::vector<unsigned int, std::allocator<unsigned int>>>(char const*, std::vector<unsigned int, std::allocator<unsigned i
    #10 ThreadPoolTest_ParallelExecution_Test::TestBody() /home/volodymyr/work/simple-threadpool/test/threadpool.cpp:113:5 (test_threadpool+0x10ce02) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #11 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (test_threadpool+0x15c55e) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)

  Previous write of size 4 at 0x72040000022c by thread T4:
    #0 decltype(::new((void*)(0)) unsigned int(std::declval<unsigned int const&>())) std::construct_at<unsigned int, unsigned int const&>(unsigned int*, unsigned int const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_construct.h:97:14 (test_threadp
    #1 void std::allocator_traits<std::allocator<unsigned int>>::construct<unsigned int, unsigned int const&>(std::allocator<unsigned int>&, unsigned int*, unsigned int const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:540:4 (test_threa
    #2 std::vector<unsigned int, std::allocator<unsigned int>>::push_back(unsigned int const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_vector.h:1286:6 (test_threadpool+0x10e299)
    #3 ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0::operator()(std::stop_token const&) const /home/volodymyr/work/simple-threadpool/test/threadpool.cpp:91:21 (test_threadpool+0x10e299)
    #4 void std::__invoke_impl<void, ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0&, std::stop_token const&>(std::__invoke_other, ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0&, std::stop_token const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c
    #5 std::enable_if<is_invocable_r_v<void, ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0&, std::stop_token const&>, void>::type std::__invoke_r<void, ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0&, std::stop_token const&>(ThreadPoolTest_ParallelExecution_Test::
    #6 std::_Function_handler<void (std::stop_token const&), ThreadPoolTest_ParallelExecution_Test::TestBody()::$_0>::_M_invoke(std::_Any_data const&, std::stop_token const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9 (test_threadp
    #7 std::function<void (std::stop_token const&)>::operator()(std::stop_token const&) const /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9 (test_threadpool+0x1172ec) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #8 wwa::thread_pool_private::run_task(std::shared_ptr<wwa::work_item> const&) /home/volodymyr/work/simple-threadpool/src/threadpool_p.cpp:188:9 (test_threadpool+0x1172ec)
    #9 wwa::thread_pool_private::worker_thread(std::stop_token const&, wwa::thread_pool_private*, unsigned long) /home/volodymyr/work/simple-threadpool/src/threadpool_p.cpp:168:23 (test_threadpool+0x115ba2) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #10 void std::__invoke_impl<void, void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>(std::__invoke_other, void (*&&)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop
    #11 std::__invoke_result<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>::type std::__invoke<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa:
    #12 void std::thread::_Invoker<std::tuple<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>>::_M_invoke<0ul, 1ul, 2ul, 3ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) /usr/bin/../lib/gcc/x86_64-li
    #13 std::thread::_Invoker<std::tuple<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>>::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:299:1
    #14 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::stop_token const&, wwa::thread_pool_private*, unsigned long), std::stop_token, wwa::thread_pool_private*, unsigned long>>>::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/b
    #15 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)

  As if synchronized via sleep:
    #0 nanosleep <null> (test_threadpool+0x730a1) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #1 void std::this_thread::sleep_for<long, std::ratio<1l, 1000000l>>(std::chrono::duration<long, std::ratio<1l, 1000000l>> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/this_thread_sleep.h:80:9 (test_threadpool+0x10c51a) (BuildId: d7b3726e31c43
    #2 ThreadPoolTest_ParallelExecution_Test::TestBody() /home/volodymyr/work/simple-threadpool/test/threadpool.cpp:99:9 (test_threadpool+0x10c51a)
    #3 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (test_threadpool+0x15c55e) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)

  Location is heap block of size 16 at 0x720400000220 allocated by main thread:
    #0 operator new(unsigned long) <null> (test_threadpool+0xf511b) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #1 std::__new_allocator<unsigned int>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/new_allocator.h:151:27 (test_threadpool+0x10c2cd) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
    #2 std::allocator<unsigned int>::allocate(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/allocator.h:198:32 (test_threadpool+0x10c2cd)
    #3 std::allocator_traits<std::allocator<unsigned int>>::allocate(std::allocator<unsigned int>&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:482:20 (test_threadpool+0x10c2cd)
    #4 std::_Vector_base<unsigned int, std::allocator<unsigned int>>::_M_allocate(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_vector.h:381:20 (test_threadpool+0x10c2cd)
    #5 std::vector<unsigned int, std::allocator<unsigned int>>::reserve(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/vector.tcc:79:22 (test_threadpool+0x10c2cd)
    #6 ThreadPoolTest_ParallelExecution_Test::TestBody() /home/volodymyr/work/simple-threadpool/test/threadpool.cpp:85:13 (test_threadpool+0x10c2cd)
    #7 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (test_threadpool+0x15c55e) (BuildId: d7b3726e31c436b261f89ba9886b40f51f9065ee)
```

These are false positives because `sleep_for()` was not used for synchronization. However, replacing the `latch.try_wait()` loop with `latch.wait()` is the right thing to do.